### PR TITLE
v2.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 ### Windows
 
 - Open and close windows
-- Minmize and maximize windows
+- Minimize and maximize windows
 - Add new tab to window
 - Customize the title and color of the window (UI only)
 
@@ -32,6 +32,7 @@
 
 - Open and close tabs
 - Pin and unpin tabs
+- Mute and unmute tabs
 - Move tabs within and between windows
 - Select multiple tabs at once with Right-Click or Ctrl+Click
 - Sort tabs by title or url

--- a/src/app.css
+++ b/src/app.css
@@ -7,8 +7,11 @@ svg:focus {
 }
 
 .sortable-selected {
-  background-color: hsl(var(--a) / var(--tw-bg-opacity));
-  border-radius: 0.375rem;
+  @apply rounded-md bg-accent
+}
+
+.sortable-selected .label-text {
+  @apply text-black
 }
 
 [class^="tippy-"] {

--- a/src/lib/chrome/windows.ts
+++ b/src/lib/chrome/windows.ts
@@ -37,6 +37,10 @@ export async function removeWindow(windowId: number) {
 	return await chrome.windows.remove(windowId);
 }
 
+export async function openWindow(windowId: number) {
+	return await chrome.windows.update(windowId, { focused: true });
+}
+
 export async function toggleMinimizedWindow(windowId: number) {
 	const window = await getWindow(windowId);
 	if (window.state === 'minimized') {

--- a/src/routes/BottomNav.svelte
+++ b/src/routes/BottomNav.svelte
@@ -10,13 +10,15 @@
 	// @ts-ignore
 	import PinOutline from 'svelte-ionicons/PinOutline.svelte';
 	// @ts-ignore
+	import VolumeMuteOutline from 'svelte-ionicons/VolumeMuteOutline.svelte';
+	// @ts-ignore
 	import TrashOutline from 'svelte-ionicons/TrashOutline.svelte';
 	// @ts-ignore
 	import EyeOutline from 'svelte-ionicons/EyeOutline.svelte';
 	// @ts-ignore
 	import EyeOffOutline from 'svelte-ionicons/EyeOffOutline.svelte';
 	import SearchBar from './SearchBar.svelte';
-	import { createTab, pinSelectedTabs, removeSelectedTabs } from '$lib/chrome/tabs';
+	import { createTab, muteSelectedTabs, pinSelectedTabs, removeSelectedTabs } from '$lib/chrome/tabs';
 	import { selectedTabsStore, windowsStore } from '$lib/stores';
 	import { createEmptyWindow } from '$lib/chrome/windows';
 	import { beforeUpdate } from 'svelte';
@@ -75,6 +77,15 @@
 				on:click={async () => await pinSelectedTabs()}
 			>
 				<PinOutline size="16" />
+			</button>
+		</li>
+		<li>
+			<button
+				class="btn btn-square btn-warning btn-sm topTippy"
+				data-tippy-content="Mute ({$selectedTabsStore.length}) tabs"
+				on:click={async () => await muteSelectedTabs()}
+			>
+				<VolumeMuteOutline size="16" />
 			</button>
 		</li>
 		<li>

--- a/static/manifest.json
+++ b/static/manifest.json
@@ -1,7 +1,7 @@
 {
 	"name": "Simple Tab Manager",
 	"description": "Simple tab manager that allows you to easily manage and sort tabs.",
-	"version": "2.0.0",
+	"version": "2.0.1",
 	"manifest_version": 3,
 
 	"icons": {


### PR DESCRIPTION
- Added a button to mute and unmute selected tabs
- Added indicator for pinned and muted tabs
- Added the ability to focus a window by clicking on it
- Changed the tab title text to always be black when selected (now visable)
- Fixed an issue where clicking on a tab sometimes didn't open it
- Fixed an issue where the tooltip didn't display the correct amount of tabs being affected